### PR TITLE
fix in openml dataset url

### DIFF
--- a/health/crawler/spiders/openml.py
+++ b/health/crawler/spiders/openml.py
@@ -21,5 +21,5 @@ class OpenmlSpider(BaseSpider):
     def get_url(self, dataset_id: str):
         """See base class."""
         return (
-            f"https://openml1.win.tue.nl/{dataset_id // 10000:04d}/{dataset_id:04d}/dataset_{dataset_id}_croissant.json"
+            f"https://openml1.win.tue.nl/datasets/{dataset_id // 10000:04d}/{dataset_id:04d}/dataset_{dataset_id}_croissant.json"
         )


### PR DESCRIPTION
Fix to use the correct URL when downloading openml datasets